### PR TITLE
update packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,35 +391,38 @@ $ php masquerade.phar groups --platform=magento2
 
 ### Building from source
 
-To build the phar from source you can use the `build.sh` script. Note that it depends on [Box](https://github.com/box-project/box2) so you need to make sure that it is available first.
+To build the phar from source you can use the `build.sh` script. Note that it depends on [Box](https://github.com/box-project/box) which is included in this repository.
 
 ```
-cd masquerade
-# Find the latest version here: https://github.com/box-project/box2#as-a-phar-recommended
-curl -LSs https://box-project.github.io/box2/installer.php | php
-composer update
-chmod u+x build.sh
-./build.sh
-bin/masquerade
+# git clone https://github.com/elgentos/masquerade
+# cd masquerade
+# composer update
+# chmod +x build.sh
+# ./build.sh
+# bin/masquerade
 ```
 
-## Generating a new release changelog
+### Debian Packaging
 
+To build a deb for this project run:
+
+```
+# apt-get install debhelper cowbuilder git-buildpackage
+# export ARCH=amd64
+# export DIST=buster
+# cowbuilder --create --distribution buster --architecture amd64 --basepath /var/cache/pbuilder/base-$DIST-amd64.cow --mirror http://ftp.debian.org/debian/ --components=main
+# echo "USENETWORK=yes" > ~/.pbuilderrc
+# git clone https://github.com/elgentos/masquerade
+# cd masquerade
+# gbp buildpackage --git-pbuilder --git-dist=$DIST --git-arch=$ARCH --git-ignore-branch -us -uc -sa --git-ignore-new
+```
+
+To generate a new `debian/changelog` for a new release:
 ```
 export BRANCH=master
 export VERSION=$(date "+%Y%m%d.%H%M%S")
 gbp dch --debian-tag="%(version)s" --new-version=$VERSION --debian-branch $BRANCH --release --commit
 ```
-
-### Packaging
-
-To build a deb that installs the phar in the dist directory run:
-
-```
-gbp buildpackage --git-pbuilder --git-dist=xenial --git-arch=amd64 --git-ignore-branch --git-ignore-new
-```
-
-Make sure you have a [cow environment](https://wiki.debian.org/git-pbuilder) configured for your branch and distribution. Keep in mind that the packaging does not build a new phar file, so if you want to package your local revision for testing please run `./build.sh` and copy the created `bin/masquerade` to `dist/masquerade.phar` first.
 
 #### Credits
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,202 @@
+masquerade (20210701.073950) UNRELEASED; urgency=medium
+
+  [ peterjaap ]
+  * Added yaml files for Magento1 - not correct because it has no EAV support yet!
+
+  [ Rick van de Loo ]
+  * add debian packaging (#7)
+
+  [ peterjaap ]
+  * Cool Carbon screenshot which is all the hype now - closes #14
+
+  [ Jan Knipper ]
+  * Added charset to command line options (#15)
+
+  [ peterjaap ]
+  * If formatter is unknown, use null for the value in order to remove personal data even though we don't have a perfect substitute - closes #2
+  * Added extra level in yaml for formatter, to add options
+  * Moved optional, unique and nullColumnBeforeRun one level deeper since it belongs to the column, not the formatter
+  * Set randomNumber to 8 digits and updated RunCommand to expand options into method parameters
+  * Allow for simple and extended syntax for formatter
+  * Implementing chunking of database retrieval
+  * New version
+  * Added fixed 'formatter' - closes #9
+  * Updated dist file
+  * Built in checks to see if table and column exist
+  * Built in checks to see if table and column exist, closes #11
+  * Added masquerade dist
+  * First code to include custom Faker providers
+  * Update dist
+  * Removed hardcoded files with a scandir
+  * Added test to see if loading actually works - now on to an autoloader
+  * Fixed config file loading for phar and non-phar
+  * Added option to supply Faker providers with formatters
+  * Updated README and dist
+  * Moved custom autoloader to custom Application class, changed order of path prefixes to look in and added break in foreach loop to prevent class already defined errors
+  * Removed duplicate declaration of isPhar()
+  * UPdated dist
+  * Fixed list command to also display formatter parameters
+  * Changed bulid process to Box, added .php71 stopfile, updated smaller dist (11M > 3M), closes #12
+  * Updated build script and README
+  * Added illuminate/support, removed config file from dist
+  * Refactored ListCommand int GroupsCommand to allow listing when no arguments are given (closes #26) and placed logo and version at top of help commands too
+  * Upped version to 0.1.1
+  * Replaced hassankhan/config with elgentos/parser (closes 22) Created configHelper to help with elgentos/parser Updated version to 0.1.2
+  * Added LICENSE & updated dist
+  * Removed dist file from repo, we'll place it under releases from now on
+  * Updated download URL
+  * Removed chmod command, Box does that for us
+  * Place nullifying outside chunking
+  * Ran phpstan level 7 and fixed errors
+  * Added Identify Command
+  * Raised version to 0.1.3
+  * Removed test config.yaml and added it to gitignore
+  * Made config.yaml also available in all config dirs
+  * Cut off example values that are longer than 30 chars
+  * Upped version to 0.1.4
+  * Added rating yaml to magento2 source files
+  * Fixed uniqueness of fields - closing #25
+  * Upped to version 0.1.5
+
+  [ Jeroen Boersma ]
+  * Updated to latest elgentos/parser:2.4.0
+
+  [ Michiel Gerritsen ]
+  * Show a warning when the correct PHP version is not available
+
+  [ peterjaap ]
+  * Raised version to 0.1.7 to create new release with phar file
+  * Add .idea to .gitignore
+  * Changed precedence order for configuration settings; inline settings now take precedence over config file, as it should
+  * Fix bug where Elgentos/Parser threw warning when parsing config YAML dir
+  * Removed firstname from customer_grid_flat table configuration since it does not exist
+  * Fixed precedence for prefix, locale and platformName, raised version to 0.1.9
+
+  [ Timon de Groot ]
+  * Fix undefined index: prefix
+  * Update elgentos/parser (2.4.0 => 2.6.1)
+  * Fix remaining undefined index notices
+  * Add xdg config path to possible configDirs
+  * Add Magento Enterprise tables
+  * Add newlines
+
+  [ Erik Hansen ]
+  * Update readme with link that will always point to latest phar
+
+  [ Peter Jaap Blaakmeer ]
+  * Update README.md
+  * Update README.md
+  * Update README.md
+
+  [ Caneco ]
+  * improvement: add brand new logo to the project
+
+  [ Peter Jaap Blaakmeer ]
+  * Apply fixes from StyleCI
+
+  [ Erik Hansen ]
+  * Update installation command to be more broadly supported
+  * Add readme making it obvious that M1 is not supported
+
+  [ Peter Jaap Blaakmeer ]
+  * Updated IP formatters for rating table
+  * Raised version to 0.1.12
+
+  [ Tjitse ]
+  * Use random number in remote_ip_long
+  * Fix remote_ip_long formatter
+
+  [ John ORourke ]
+  * updated README to clarify --group syntax
+  * WIP on allowing different types of linked/EAV tables
+
+  [ John ]
+  * WIP - Simple table type now works
+
+  [ John ORourke ]
+  * styleci fixes
+  * updated README and added config samples for delete/where options and custom table types
+  * fixed build.sh to work with the default box installer process
+
+  [ John ]
+  * added CLI option to specify a custom config folder
+  * allow table config "provider" option to be an option array with optional "class"
+  * Tested and working with Magento 2.3.4, Amasty Order Attributes, and regular tables
+  * non-functional changes: style fixes and optimisation
+  * update to allow multiple --config options eg. --config=./global --config=./local
+  * Added sensible defaults for primary key guessing; Simple table type now allows subclass to override orderBy; support multiple EAV attributes of the same type; warn if using WHERE on a nulled column
+  * Get accurate count for the progress bar even when using groupBy due to per-store values
+
+  [ Tjitse Efdé ]
+  * Add option to specify database port
+  * Add port option to readme, set default port to 3306
+
+  [ Peter Jaap Blaakmeer ]
+  * Updated illuminate/database updated from v5.8.35 to v6.20.13 and accompanying packages
+  * Raised version to 0.1.13
+
+  [ John ]
+  * separate delete/truncate options to allow foreign key constraints to be met
+  * added example magento2 configs with sales orders deleted
+  * illuminate 6.20 removed array_get/array_first helpers - replace with Arr::get Arr::first
+  * added --with-integrity option to enable foreign key constraints; use Illuminate Arr class instead of array_get; finished documenting new features
+  * syntax fix
+  * missing class added in lieu of #57
+
+  [ Peter Jaap Blaakmeer ]
+  * Raised version to 0.2
+
+  [ dependabot[bot] ]
+  * Bump illuminate/database from 6.20.13 to 6.20.14
+  * Fix built dist, raised version to 0.2.1
+  * Added try/catch block to not fail on missing tables (like EE tables in a CE install)
+  * Raised version to 0.2.2
+  * Raised version to 0.2.3
+  * Apply fixes from StyleCI
+  * Create login as customer definition
+  * Raised version to 0.2.4
+  * Deleted PHP 7.1 stopfile
+
+  [ Erfan ]
+  * Fixes #48: Added config for sales_order_payment table
+
+  [ Peter Jaap Blaakmeer ]
+  * Updated build command
+  * Raised version to 0.2.5
+
+  [ Ivan Chepurnyi ]
+  * - Significant improvement in performance of anonymization - More feedback during process execution - Removed inheritance as extension mechanism
+  * Fix missing newline characters at EOF
+  * Apply Style CI adjustments
+  * Few bugfixes: - Fix issue with progress bar drawing in non-ansi mode - Fix issue with table prefix being duplicated
+  * Remove possible name conflict with internally overriden variable
+
+  [ Peter Jaap Blaakmeer ]
+  * Raised version to 0.3.0
+
+  [ Tjitse Efdé ]
+  * Fix array to string conversion
+
+  [ Ivan Chepurnyi ]
+  * Fix issue with table alias on delete and truncate statements
+
+  [ dependabot[bot] ]
+  * Bump illuminate/database from 6.20.14 to 6.20.26
+
+  [ Peter Jaap Blaakmeer ]
+  * Raise version to 0.3.1
+
+  [ Timon de Groot ]
+  * Update README.md
+
+  [ Tjitse ]
+  * Mysql 8 fixes
+
+  [ Peter Jaap Blaakmeer ]
+  * Raised version to 0.3.2
+
+ -- peterjaap <peterjaap@elgentos.nl>  Thu, 01 Jul 2021 07:40:06 +0200
+
 masquerade (20180711.080851) xenial; urgency=medium
 
   [ Rick van de Loo ]

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,9 @@
 Source: masquerade
 Priority: optional
 Maintainer: Peter Jaap Blaakmeer <peterjaap@elgentos.nl>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), git, php7.3-cli, php7.3-mbstring,
+    php7.3-xml, composer, ca-certificates, wget
 Standards-Version: 3.9.4
-Section: libs
 Homepage: https://github.com/elgentos/masquerade
 Vcs-Git: git@github.com:elgentos/masquerade.git
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,11 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+build:
+	composer update
+	chmod +x build.sh
+	./build.sh
+
 override_dh_usrlocal:
 
 %:


### PR DESCRIPTION
```
root@levkcl-hntestmerel2020-magweb-cmbl /tmp # dpkg -L masquerade
/.
/usr
/usr/local
/usr/local/bin
/usr/local/bin/masquerade.phar
/usr/share
/usr/share/doc
/usr/share/doc/masquerade
/usr/share/doc/masquerade/README.md.gz
/usr/share/doc/masquerade/changelog.gz
root@levkcl-hntestmerel2020-magweb-cmbl /tmp # which masquerade
/usr/local/bin/masquerade
root@levkcl-hntestmerel2020-magweb-cmbl /tmp # ls -stlhra /usr/local/bin/masquerade
0 lrwxrwxrwx 1 root root 30 Jul  1 09:01 /usr/local/bin/masquerade -> /usr/local/bin/masquerade.phar
root@levkcl-hntestmerel2020-magweb-cmbl /tmp # masquerade --version

._ _  _. _ _.    _ .__. _| _
| | |(_|_>(_||_|(/_|(_|(_|(/_
            |
                   by elgentos 0.3.2
root@levkcl-hntestmerel2020-magweb-cmbl /tmp # masquerade --help
Description:
  List commands

Usage:
  list [options] [--] [<namespace>]

Arguments:
  namespace            The namespace name

Options:
      --raw            To output raw command list
      --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]

Help:
  The list command lists all commands:
  
    php /usr/local/bin/masquerade list
  
  You can also display the commands for a specific namespace:
  
    php /usr/local/bin/masquerade list test
  
  You can also output the information in other formats by using the --format option:
  
    php /usr/local/bin/masquerade list --format=xml
  
  It's also possible to get raw list of commands (useful for embedding command runner):
  
    php /usr/local/bin/masquerade list --raw
```

note that this package doesn't only works for certain PHP versions at this time:
```
root@levkcl-hntestmerel2020-magweb-cmbl /tmp # masquerade --help

Box Requirements Checker
========================

> Using PHP 8.0.7
> PHP is using the following php.ini file:
  /etc/php/8.0/cli/php.ini

> Checking Box requirements:
  E.....

                                                                                
 [ERROR] Your system is not ready to run the application.                       
                                                                                

Fix the following mandatory requirements:
=========================================

 * The application requires the version "^7.2" or greater.

```